### PR TITLE
Move setup work out of flask startup into docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,5 +20,7 @@ RUN python3.7 -m pip install -r requirements.txt
 
 COPY . /server
 
+RUN python3.7 -c "import text_rank; text_rank.process_word_embeddings()"
+
 ENV FLASK_APP=server.py
 CMD ["flask", "run", "--host=0.0.0.0"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN python3.7 -m pip install -r requirements.txt
 
 COPY . /server
 
-RUN python3.7 -c "import text_rank; text_rank.process_word_embeddings()"
+RUN python3.7 -c "import text_rank; text_rank.setup_local_data()"
 
 ENV FLASK_APP=server.py
 CMD ["flask", "run", "--host=0.0.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+black
 flask>=1.0.2
-numpy
+ipython
+networkx
 nltk
+numpy
 pandas
 sklearn
-networkx
-black

--- a/server.py
+++ b/server.py
@@ -27,4 +27,4 @@ def summarize():
     if not request.is_json:
         abort(400)
     request_payload = request.get_json()
-    return "".join(text_rank.summarize(request_payload["text"]))
+    return json.dumps(text_rank.summarize(request_payload["text"]))

--- a/text_rank.py
+++ b/text_rank.py
@@ -34,7 +34,7 @@ def setup_local_data():
     ):
         return
 
-    with open("/data/glove.6B.100d.txt", "r", encoding="utf-8") as file:
+    with open("/data/glove.6B.300d.txt", "r", encoding="utf-8") as file:
         for line in file:
             values = line.split()
             word = values[0]

--- a/text_rank.py
+++ b/text_rank.py
@@ -17,19 +17,17 @@ stop_words = set()
 
 
 def setup():
-    nltk.download("punkt")
-    nltk.download("stopwords")
-
     # TODO: consider how to handle languages other than English
     stop_words = set(corpus.stopwords.words("english"))
-    process_word_embeddings()
-
     with open(WORD_EMBEDDINGS_FILE, "rb") as handle:
         word_embeddings = pickle.load(handle)
 
 
 # This should be run from the Dockerfile
-def process_word_embeddings():
+def setup_local_data():
+    nltk.download("punkt")
+    nltk.download("stopwords")
+
     if (
         os.path.exists(WORD_EMBEDDINGS_FILE)
         and os.path.getsize(WORD_EMBEDDINGS_FILE) > 0


### PR DESCRIPTION
I was doing a bunch of `docker-compose up` and realized that the flask app was taking ~10s each time to process the glove data.

This change processes that data in the dockerfile so that we can just read in the processed data when the flask app starts.