### PR TITLE
Put local data earlier in docker cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,13 +16,17 @@ RUN unzip /data/glove*.zip -d /data && \
 
 RUN python3.7 -m pip install pip
 
-COPY ./requirements.txt /server/requirements.txt
 WORKDIR /server
+
+# Python package dependencies
+COPY ./requirements.txt /server/requirements.txt
 RUN python3.7 -m pip install -r requirements.txt
 
-COPY . /server
+# Set up local data
+COPY ./image_setup.py /server/image_setup.py
+RUN python3.7 -c "import image_setup; image_setup.setup_local_data()"
 
-RUN python3.7 -c "import text_rank; text_rank.setup_local_data()"
+COPY . /server
 
 # ENV FLASK_APP=server.py
 CMD ["python3.7", "server.py"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,10 +23,13 @@ COPY ./requirements.txt /server/requirements.txt
 RUN python3.7 -m pip install -r requirements.txt
 
 # Set up local data
+# The symlink has to be made because for some reason when the container is run
+# in google cloud run, nltk checks for data at /home/nltk_data. When the
+# container is run locally, it checks /root/nltk_data.
 COPY ./image_setup.py /server/image_setup.py
-RUN python3.7 -c "import image_setup; image_setup.setup_local_data()"
+RUN python3.7 -c "import image_setup; image_setup.setup_local_data()" && \
+    ln -s /root/nltk_data /home/nltk_data
 
 COPY . /server
 
-# ENV FLASK_APP=server.py
 CMD ["python3.7", "server.py"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,5 +24,5 @@ COPY . /server
 
 RUN python3.7 -c "import text_rank; text_rank.setup_local_data()"
 
-ENV FLASK_APP=server.py
-CMD ["flask", "run", "--host=0.0.0.0"]
+# ENV FLASK_APP=server.py
+CMD ["python3.7", "server.py"]

--- a/image_setup.py
+++ b/image_setup.py
@@ -1,0 +1,30 @@
+import pickle
+import os
+
+import nltk
+import numpy as np
+
+WORD_EMBEDDINGS_FILE = "/data/word_embeddings.pickle"
+
+
+# This should be run from the Dockerfile
+def setup_local_data():
+    nltk.download("punkt")
+    nltk.download("stopwords")
+
+    if (
+        os.path.exists(WORD_EMBEDDINGS_FILE)
+        and os.path.getsize(WORD_EMBEDDINGS_FILE) > 0
+    ):
+        return
+
+    word_embeddings = {}
+    with open("/data/glove.6B.300d.txt", "r", encoding="utf-8") as file:
+        for line in file:
+            values = line.split()
+            word = values[0]
+            coefs = np.asarray(values[1:], dtype="float32")
+            word_embeddings[word] = coefs
+
+    with open(WORD_EMBEDDINGS_FILE, "wb") as handle:
+        pickle.dump(word_embeddings, handle)

--- a/server.py
+++ b/server.py
@@ -1,9 +1,11 @@
-from flask import Flask, abort, request
 import json
+import os
+
+from flask import Flask, abort, request
+import text_rank
 
 app = Flask(__name__)
 
-import text_rank
 
 
 @app.before_first_request
@@ -28,3 +30,7 @@ def summarize():
         abort(400)
     request_payload = request.get_json()
     return json.dumps(text_rank.summarize(request_payload["text"]))
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))

--- a/server.py
+++ b/server.py
@@ -7,7 +7,6 @@ import text_rank
 app = Flask(__name__)
 
 
-
 @app.before_first_request
 def before_first_request():
     text_rank.setup()

--- a/text_rank.py
+++ b/text_rank.py
@@ -9,8 +9,7 @@ import pandas as pd
 from nltk import tokenize
 from nltk import corpus
 from sklearn.metrics.pairwise import cosine_similarity
-
-WORD_EMBEDDINGS_FILE = "/data/word_embeddings.pickle"
+from image_setup import WORD_EMBEDDINGS_FILE
 
 word_embeddings = {}
 stop_words = set()
@@ -21,28 +20,6 @@ def setup():
     stop_words = set(corpus.stopwords.words("english"))
     with open(WORD_EMBEDDINGS_FILE, "rb") as handle:
         word_embeddings = pickle.load(handle)
-
-
-# This should be run from the Dockerfile
-def setup_local_data():
-    nltk.download("punkt")
-    nltk.download("stopwords")
-
-    if (
-        os.path.exists(WORD_EMBEDDINGS_FILE)
-        and os.path.getsize(WORD_EMBEDDINGS_FILE) > 0
-    ):
-        return
-
-    with open("/data/glove.6B.300d.txt", "r", encoding="utf-8") as file:
-        for line in file:
-            values = line.split()
-            word = values[0]
-            coefs = np.asarray(values[1:], dtype="float32")
-            word_embeddings[word] = coefs
-
-    with open(WORD_EMBEDDINGS_FILE, "wb") as handle:
-        pickle.dump(word_embeddings, handle)
 
 
 def remove_stopwords(sen):


### PR DESCRIPTION
This means that if we change server.py or text_rank.py, we don't have to re-process the glove data when rebuilding the docker image.

Also a few changes so that this can run on google cloud run, which I'm experimenting with.